### PR TITLE
Updated URLs for dwc-components.json to use dwc.style URLs

### DIFF
--- a/docs/client-components/create_files.js
+++ b/docs/client-components/create_files.js
@@ -6,7 +6,7 @@ if (!fs.existsSync(outputDirectory)) {
 }
 
 // Sample JSON data (replace with your actual data)
-const jsonUrl = 'https://basishub.github.io/basis-next/docs/dwc-components.json';
+const jsonUrl = 'https://dwc.style/docs/dwc-components.json';
 
 async function fetchData() {
   try {

--- a/docs/components/navigator.md
+++ b/docs/components/navigator.md
@@ -16,7 +16,7 @@ import Chip from '@mui/material/Chip';
 
 <DocChip tooltipText="This component will render with a shadow DOM, an API built into the browser that facilitates encapsulation." label="Shadow" component="a" href="../glossary#shadow-dom" target="_blank" clickable={true} iconName="shadow" />
 
-<DocChip tooltipText="The name of the web component that will render in the DOM." label="dwc-navigator" href="https://basishub.github.io/basis-next/#/web-components/dwc-navigator" clickable={false} iconName='code'/>
+<DocChip tooltipText="The name of the web component that will render in the DOM." label="dwc-navigator" href="https://dwc.style/docs/#/web-components/dwc-navigator" clickable={false} iconName='code'/>
 
 
 <JavadocLink type="foundation" location="com/webforj/component/navigator/Navigator" top='true'/>

--- a/src/components/DocsTools/TableBuilder.js
+++ b/src/components/DocsTools/TableBuilder.js
@@ -8,7 +8,7 @@ export default function TableBuilder(props) {
   const [component, setComponent] = useState(null);
 
   useEffect(() => {
-    fetch("https://basishub.github.io/basis-next/docs/dwc-components.json")
+    fetch("https://dwc.style/docs/dwc-components.json")
       .then((response) => response.json())
       .then((data) => {
         const selectedComponent = data.components.find(


### PR DESCRIPTION
I updated 3 links across the documentation to sue the dwc.style URLs. 
Most notably, the TableBuilder will now work with these URLs since the GitHub site is down.
Thanks for the updated links, Hyyan!