### PR TITLE
PR Added Slots section for TabbedPane

### DIFF
--- a/docs/components/tabbed-pane.md
+++ b/docs/components/tabbed-pane.md
@@ -61,6 +61,15 @@ Tabs are comprised of the following properties, which are then used when adding 
 
 5. **Closeable(`boolean`)**: Represents whether the `Tab` can be closed. Can be modified with the `setCloseable(boolean enabled)` method. This will add a close button on the `Tab` which can be clicked on by the user, and fires a removal event. The     `TabbedPane` component dictates how to handle the removal.
 
+6. **Slot(`Component`)**: 
+    Slots provide flexible options for improving the functionality of a `Tab`. You can have icons, labels, loading spinners, clear/reset capability, avatar/profile pictures, and other beneficial components nested within a `Tab` to further clarify intended meaning to users.
+    You can add a component to the `prefix` slot of a `Tab` during construction. Alternatively, you can use the `setPrefixComponent()` and `setSuffixComponent()` methods to insert various components before and after the displayed option within a `Tab`.
+
+        ```java
+        TabbedPane pane = new TabbedPane();
+            pane.addTab(new Tab("Documents", TablerIcon.create("files")));
+        ```
+
 ## `Tab` Manipulation
 
 Various methods exist to allow developers to add, insert, remove and manipulate various properties of `Tab` elements within the `TabbedPane`.

--- a/docs/components/tabbed-pane.md
+++ b/docs/components/tabbed-pane.md
@@ -62,12 +62,12 @@ Tabs are comprised of the following properties, which are then used when adding 
 5. **Closeable(`boolean`)**: Represents whether the `Tab` can be closed. Can be modified with the `setCloseable(boolean enabled)` method. This will add a close button on the `Tab` which can be clicked on by the user, and fires a removal event. The     `TabbedPane` component dictates how to handle the removal.
 
 6. **Slot(`Component`)**: 
-    Slots provide flexible options for improving the functionality of a `Tab`. You can have icons, labels, loading spinners, clear/reset capability, avatar/profile pictures, and other beneficial components nested within a `Tab` to further clarify intended meaning to users.
+    Slots provide flexible options for improving the capability of a `Tab`. You can have icons, labels, loading spinners, clear/reset capability, avatar/profile pictures, and other beneficial components nested within a `Tab` to further clarify intended meaning to users.
     You can add a component to the `prefix` slot of a `Tab` during construction. Alternatively, you can use the `setPrefixComponent()` and `setSuffixComponent()` methods to insert various components before and after the displayed option within a `Tab`.
 
         ```java
         TabbedPane pane = new TabbedPane();
-            pane.addTab(new Tab("Documents", TablerIcon.create("files")));
+        pane.addTab(new Tab("Documents", TablerIcon.create("files")));
         ```
 
 ## `Tab` Manipulation


### PR DESCRIPTION
This PR closes #222.
Added a section to [Tab Properties](https://documentation.webforj.com/docs/components/tabbedpane#properties) talking about adding slots using the constructor, the `setPrefixComponent()` method, and the `setSuffixComponent()` method.