### PR TITLE
PR New tab button for `AppLayoutViewer` 

### DIFF
--- a/docs/components/app-layout.md
+++ b/docs/components/app-layout.md
@@ -34,10 +34,7 @@ Each part of the layout is a `Div`, which can contain any valid webforJ control.
 
 The following code sample will result in an application with a collapsible sidebar that contains a logo and tabs for various content options and a header. The demo uses the dwc-icon-button web component to create a drawer toggle button. The button has the data-drawer-toggle attribute which instructs the DwcAppLayout to listen to click events coming from that component to toggle the drawer state.
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/applayout?' mobile='false' />
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/applayout?' mobile='false'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/applayout/AppLayoutView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_styles.css'
 />
@@ -53,11 +50,7 @@ myApp.setHeaderOffscreen(false);
 myApp.setFooterOffscreen(false);
 ```
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/applayoutfullnavbar?' mobile='false'/>
-
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/applayoutfullnavbar?' mobile='false'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/applayout/AppLayoutFullNavbarView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_styles.css'
 />
@@ -69,10 +62,7 @@ The navbar has no limit to the number of toolbars you can add. A toolbar is only
 
 The following demo shows how to use two toolbars, The first one houses the drawer's toggle button and the application's title. The second toolbar houses a secondary navigation menu.
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/applayoutmultipleheaders?' mobile='false'/>
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/applayoutmultipleheaders?' mobile='false'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/applayout/AppLayoutMultipleHeadersView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_styles.css'
 />
@@ -87,14 +77,10 @@ When `AppLayout.setHeaderReveal(true)` is set called, the header will be visible
 
 With the help of the CSS custom property `--dwc-app-layout-header-collapse-height` it is possible to control how much of the header navbar will be hidden.
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/applayoutstickytoolbar?' mobile='false'/>
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/applayoutstickytoolbar?' mobile='false'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/applayout/AppLayoutStickyToolbarView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_sticky_styles.css'
 />
-
 
 ### Mobile Navigation Layout
 
@@ -106,10 +92,7 @@ Same as `AppLayout.setHeaderReveal()`, `AppLayout.setFooterReveal()` is supporte
 
 Be default, when the screen width is 800px or less , the drawer will be switched to popover mode. This is called the breakpoint. The popover mode means that the drawer will pop over the content area with an overlay. It is possible to configure the breakpoint by using the DwcAppLayout:setDrawerBreakpoint method and the breakpoint must be a valid [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/applayoutmobile?' mobile='true'/>
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/applayoutmobile?' mobile='true'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/applayout/AppLayoutMobileView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_mobile.css'
 />
@@ -125,14 +108,10 @@ AppLayout demo = new AppLayout();
 demo.setDrawerBreakpoint("(max-width:500px)");
 ```
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/applayoutmobiledrawer?' mobile='true'/>
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/applayoutmobiledrawer?' mobile='true'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/applayout/AppLayoutMobileDrawerView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_mobile.css'
 />
-
 
 ## Styling
 

--- a/docs/components/drawer.md
+++ b/docs/components/drawer.md
@@ -8,10 +8,7 @@ The drawer is a container that slides into the viewport to expose additional opt
 
 The Drawer component can be used in many different situations, such as by providing a navigation menu that can be toggled, a panel that displays supplementary or contextual information, or to optimize usage on a mobile device. The following example will show a mobile application that uses the webforJ AppLayout component, and displays a "Welcome Popup" drawer at the bottom when first loaded. Additionally, a navigational Drawer component can be toggled in the application by clicking on the hamburger menu.
 
-<AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples/drawerwelcome?' mobile='true'/>
-
-<ComponentDemo 
-frame="hidden"
+<AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples/drawerwelcome?' mobile='true'
 javaE='https://raw.githubusercontent.com/webforj/webforj-docs-samples/refs/heads/main/src/main/java/com/webforj/samples/views/drawer/DrawerWelcomeView.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/drawerstyles/drawer_welcome.css'
 />

--- a/docs/components/lists/choice-box.md
+++ b/docs/components/lists/choice-box.md
@@ -14,9 +14,7 @@ slug: choicebox
 
 The `ChoiceBox` component is a user interface element designed to present users with a list of options or choices. Users can select a single option from this list, typically by clicking the `ChoiceBox`, which triggers the display of a dropdown list containing available choices. Users can also interact with the `ChoiceBox` with the arrow keys. When a user makes a selection, the chosen option is then displayed in the `ChoiceBox` button. 
 
-<!-- <AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples?class=componentdemos.choiceboxdemos.ChoiceBoxDemo' mobile='false'/>
-<ComponentDemo
-frame="hidden"
+<!-- <AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples?class=componentdemos.choiceboxdemos.ChoiceBoxDemo' mobile='false'
 javaE='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/java/componentdemos/choiceboxdemos/ChoiceBoxDemo.java'
 cssURL='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/resources/css/applayoutstyles/applayout_styles.css'
 /> -->

--- a/docs/components/tabbed-pane.md
+++ b/docs/components/tabbed-pane.md
@@ -122,10 +122,7 @@ The `TabbedPane` class has two constituent parts: a `Tab` that is displayed in a
 
 The `TabbedPane` supports navigating through the various tabs via swiping. This is ideal for a mobile application, but can also be configured via a built-in method to support mouse swiping. Both swiping and mouse swipping are disabled by default, but can be enabled with the `setSwipable(boolean)` and `setSwipableWithMouse(boolean)` methods, respectively. 
 
-<!-- <AppLayoutViewer url='https://demo.webforj.com/webapp/controlsamples?class=componentdemos.tabbedpanedemos.TabbedPaneSwipe&platform=mobile' mobile='true'/>
-
-<ComponentDemo 
-frame="hidden"
+<!-- <AppLayoutViewer path='https://demo.webforj.com/webapp/controlsamples?class=componentdemos.tabbedpanedemos.TabbedPaneSwipe&platform=mobile' mobile='true'
 javaE='https://raw.githubusercontent.com/webforj/ControlSamples/main/src/main/java/componentdemos/tabbedpanedemos/TabbedPaneSwipe.java'
 /> -->
 

--- a/src/components/DocsTools/AppLayoutViewer.js
+++ b/src/components/DocsTools/AppLayoutViewer.js
@@ -1,12 +1,14 @@
 /** @jsxImportSource @emotion/react */
 
-import React from 'react'
+import { React, useState} from 'react'
 import { jsx, css } from '@emotion/react';
 import { useColorMode } from '@docusaurus/theme-common';
+import ComponentDemo, {OpenNewWindowButton} from './ComponentDemo';
 
-
-export default function AppLayoutViewer({url, mobile}) {
+export default function AppLayoutViewer({path, mobile, javaE, cssURL}) {
     
+  const [buttonVisible, setButtonVisible] = useState(false);
+
     const demoStyles = css`
         display: flex;
         flex-direction: column;
@@ -32,14 +34,31 @@ export default function AppLayoutViewer({url, mobile}) {
         height: 100%;
         background: var(--dwc-surface-3);
     `
+    const fadeInButton = css`
+      display: flex;
+      justify-content: flex-end;
+      opacity: 0;
+      transition: opacity 0.3s ease-in-out;
+      ${buttonVisible && "opacity: 1;"};
+      margin: 10px 0 0 0;
+      position: absolute;
+      top: 10px;
+      right: 5px;
+    `
 
   return (
     <div css={demoStyles}>
-        <div css={demoPreview}>
-            <iframe src={url+"&__theme__="+ (useColorMode().colorMode)} css={demoContent} loading='lazy'>
-
+        <div css={demoPreview}
+          onMouseEnter={() => setButtonVisible(true)}
+          onMouseLeave={() => setButtonVisible(false)}>
+        <div css={fadeInButton}>
+                {OpenNewWindowButton({ url: path })}
+        </div>
+            <iframe src={path+"&__theme__="+ (useColorMode().colorMode)} css={demoContent} loading='lazy'>
             </iframe>
         </div>
+        <br/>
+        <ComponentDemo frame="hidden" javaE={javaE} cssURL={cssURL}/>
     </div>
   );
 }

--- a/src/components/DocsTools/ComponentDemo.js
+++ b/src/components/DocsTools/ComponentDemo.js
@@ -73,7 +73,7 @@ function CodeToggleButton({ collapse, setCollapse }) {
   );
 }
 
-function OpenNewWindowButton({ url }) {
+export function OpenNewWindowButton({ url }) {
   const buttonStyles = css`
     position: relative;
     cursor: pointer;


### PR DESCRIPTION
This PR close #271.
- `AppLayoutViewer` now takes `javaE` and `cssURL` attributes to generate the following `ComponentDemo`.
- Changed the `url` parameter for `AppLayoutViewer` to `path`. This follows the `ComponentDemo` naming convention.
- Updated instances of `AppLayoutViewer` with `url` parameter and removed the `ComponentDemo` after.