### PR TITLE
PR to adjust Vale settings

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -5,9 +5,11 @@ Packages = Google
 
 [*.{md,txt}]
 BasedOnStyles = Google
-; Google.Semicolons = NO
+Google.Semicolons = NO
 Google.Passive = NO
 Google.Will = NO
+Google.Parens = NO
+Google.Latin = NO
 
 [formats]
 mdx = md


### PR DESCRIPTION
This PR is to reduce the amount of errors that show up whenever an article includes sample code or method names.