### PR TITLE
PR: Hide navigation items on the right on smaller screen widths

### DIFF
--- a/src/css/_navbar.scss
+++ b/src/css/_navbar.scss
@@ -58,5 +58,12 @@
       display: none;
     }
   }
+
+  @media (max-width: 1180px){
+    .dropdown--right{
+      display: none;
+    }
+  }
+
 }
 


### PR DESCRIPTION
This PR closes #297 

Current behavior of the navigation bar between 997 and 1180 pixels:
![current](https://github.com/user-attachments/assets/14f3250a-9545-4f0b-9007-1362b84c1114)

This PR removes the navigation items to the right, but keeps the search bar when the screen width is smaller than 1180 pixels:
![pr](https://github.com/user-attachments/assets/edeb64c9-6421-4885-8407-84cd3e6382e0)
