### PR TITLE
PR: Resolved Inline Authors Warnings

### DIFF
--- a/blog/2024-04-08-webforj-v24.00/24.00.md
+++ b/blog/2024-04-08-webforj-v24.00/24.00.md
@@ -3,10 +3,7 @@ title: Whats new in version 24.00?
 description: Get to know the features, fixes and functionality new in webforJ version 24.00.
 slug: whats-new-24.00
 date: 2024-04-08
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.00, release]
 image: 'https://documentation.webforj.com/release_blog/_images/24.00-social.png'
 hide_table_of_contents: false

--- a/blog/2024-04-26-webforj-v24.01/24.01.md
+++ b/blog/2024-04-26-webforj-v24.01/24.01.md
@@ -3,10 +3,7 @@ title: Whats new in version 24.01?
 description: Get to know the features, fixes and functionality new in webforJ version 24.01.
 slug: whats-new-24.01
 date: 2024-04-26
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.01, release]
 image: 'https://documentation.webforj.com/release_blog/_images/24.01-social.png'
 hide_table_of_contents: false

--- a/blog/2024-06-03-webforj-v24.02/24.02.md
+++ b/blog/2024-06-03-webforj-v24.02/24.02.md
@@ -3,10 +3,7 @@ title: Whats new in version 24.02?
 description: Get to know the features, fixes and functionality new in webforJ version 24.02.
 slug: whats-new-24.02
 date: 2024-06-03
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.02, release]
 image: 'https://documentation.webforj.com/release_blog/_images/24.02-social.png'
 hide_table_of_contents: false

--- a/blog/2024-07-23-webforj-v24.10/24.10.md
+++ b/blog/2024-07-23-webforj-v24.10/24.10.md
@@ -3,10 +3,7 @@ title: What's new in version 24.10?
 description: Get to know the features, fixes, and functionality new in webforJ version 24.10.
 slug: whats-new-24.10
 date: 2024-07-23
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.10, release]
 image: 'https://documentation.webforj.com/release_blog/_images/24.10-social.png'
 hide_table_of_contents: false

--- a/blog/2024-09-05-webforj-v24.11/24.11.md
+++ b/blog/2024-09-05-webforj-v24.11/24.11.md
@@ -3,10 +3,7 @@ title: What's new in version 24.11?
 description: Get to know the features, fixes, and functionality new in webforJ version 24.11.
 slug: whats-new-v24.11
 date: 2024-09-05
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.11, release]
 image: 'https://documentation.webforj.com/release_blog/_images/social-cover-24.11.png'
 hide_table_of_contents: false

--- a/blog/2024-10-11-webforj-v24.12/24.12.md
+++ b/blog/2024-10-11-webforj-v24.12/24.12.md
@@ -3,10 +3,7 @@ title: What's new in version 24.12?
 description: Get to know the features, fixes, and functionality new in webforJ version 24.12.
 slug: whats-new-v24.12
 date: 2024-10-14
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.12, release]
 image: 'https://documentation.webforj.com/release_blog/_images/social-cover-24.12.png'
 hide_table_of_contents: false

--- a/blog/2024-11-25-webforj-v24.20/24.20.md
+++ b/blog/2024-11-25-webforj-v24.20/24.20.md
@@ -3,10 +3,7 @@ title: What's new in version 24.20?
 description: Get to know the features, fixes, and functionality new in webforJ version 24.20.
 slug: whats-new-v24.20
 date: 2024-11-25
-authors:
-  - name: webforJ Team
-    url: https://github.com/webforj
-    image_url: /img/webforj_icon.svg
+authors: webforJ
 tags: [webforJ, v24.20, release]
 image: 'https://documentation.webforj.com/release_blog/_images/social-cover-24.20.png'
 hide_table_of_contents: false

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,0 +1,4 @@
+webforJ:
+  name: webforJ Team
+  url: https://github.com/webforj
+  image_url: /img/webforj_icon.svg

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -2,3 +2,4 @@ webforJ:
   name: webforJ Team
   url: https://github.com/webforj
   image_url: /img/webforj_icon.svg
+  title: webforJ Development Team


### PR DESCRIPTION
This PR closes Issue #319.
Global authors can now be defined in blog/authors.yml.