### PR TITLE
chore: Deleted markdown-page.md

### DIFF
--- a/src/pages/markdown-page.md
+++ b/src/pages/markdown-page.md
@@ -1,7 +1,0 @@
----
-title: Markdown page example
----
-
-# Markdown page example
-
-You don't need React to write simple standalone pages.


### PR DESCRIPTION
This PR deletes [markdown-page.md](src/pages/markdown-page.md), which will remove this seemingly insignificant page: https://docs.webforj.com/markdown-page. Currently, **Markdown page example** is the first result when searching with a wild card (*).