### PR TITLE
chore: Renamed "Slots" Sections to "Prefix and suffix"

### DIFF
--- a/docs/components/fields/fields.md
+++ b/docs/components/fields/fields.md
@@ -34,7 +34,7 @@ Field components contain built-in visual validation to notify users when a requi
 
 By using `setSpellCheck(true)`, you can allow the browser or user agent to verify the spelling of the text entered by the user and identify any errors.
 
-### Slots
+### Prefix and suffix
 
 Slots provide flexible options for improving the capability of field components. You can have icons, labels, loading spinners, clear/reset capability, avatar/profile pictures, and other beneficial components nested within a field to further clarify intended meaning to users.
 Fields have two slots: the `prefix` and `suffix` slots. Use the `setPrefixComponent()` and `setSuffixComponent()` methods to insert various components before and after the displayed option within a field. Here's an example using the `TextField` field:

--- a/docs/components/lists/choice-box.md
+++ b/docs/components/lists/choice-box.md
@@ -103,7 +103,7 @@ The `ChoiceBox` component has methods that allow manipulation of the dropdown di
 Passing a `String` value to either of these methods will allow for [any valid CSS unit](https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units) to be applied, such as pixels, viewport dimensions, or other valid rules. Passing an `int` will set the value passed in pixels.
 :::
 
-## Slots
+## Prefix and suffix
 
 Slots provide flexible options for improving the capability of a `ChoiceBox`. You can have icons, labels, loading spinners, clear/reset capability, avatar/profile pictures, and other beneficial components nested within a `ChoiceBox` to further clarify intended meaning to users.
 The `ChoiceBox` has two slots: the `prefix` and `suffix` slots. Use the `setPrefixComponent()` and `setSuffixComponent()` methods to insert various components before and after the displayed option within a `ChoiceBox`.

--- a/docs/components/lists/combo-box.md
+++ b/docs/components/lists/combo-box.md
@@ -142,7 +142,7 @@ Contents of the component are never automatically highlighted when the component
 If content was highlighted upon losing focus, it will be highlighted again upon regaining focus, regardless of the set behavior.
 :::
 
-## Slots
+## Prefix and suffix
 
 Slots provide flexible options for improving the capability of a `ComboBox`. You can have icons, labels, loading spinners, clear/reset capability, avatar/profile pictures, and other beneficial components nested within a `ComboBox` to further clarify intended meaning to users.
 The `ComboBox` has two slots: the `prefix` and `suffix` slots. Use the `setPrefixComponent()` and `setSuffixComponent()` methods to insert various components before and after the options within a `ComboBox`.


### PR DESCRIPTION
This PR closes issue #328.

Additionally, this PR renames the "Slots" title for the [ComboBox](https://docs.webforj.com/docs/components/lists/combobox#slots) and [ChoiceBox](https://docs.webforj.com/docs/components/lists/choicebox#slots) sections that also talk about the prefix and suffix slots.


