### PR TITLE
feat: Component Chips goes to Specific Parts in Client-Component Overview

### DIFF
--- a/docs/components/google-charts.md
+++ b/docs/components/google-charts.md
@@ -7,8 +7,7 @@ import Chip from '@mui/material/Chip';
 
 <DocChip chip='shadow' />
 
-<!-- UPDATE THE NAME FOR THE CLIENT COMPONENT HERE (label="???") -->
-<DocChip chip='name' label="google-chart" />
+<DocChip chip='name' label="google-chart" exclude= 'true' />
 
 <JavadocLink type="googlecharts" location="com/webforj/component/googlecharts/GoogleChart" top='true'/>
 

--- a/docs/components/progressbar.md
+++ b/docs/components/progressbar.md
@@ -4,7 +4,7 @@ title: ProgressBar
 
 <DocChip chip='shadow' />
 
-<DocChip chip='name' label="dwc-progress-bar" />
+<DocChip chip='name' label="dwc-progressbar" />
 
 <JavadocLink type="foundation" location="com/webforj/component/progressbar/ProgressBar" top='true'/>
 

--- a/src/components/DocsTools/DocChip.js
+++ b/src/components/DocsTools/DocChip.js
@@ -39,9 +39,9 @@ export default function DocChip( { chip, label, href, clickable, iconName, toolt
     // A "DOM Name" chip
     tooltipText="The name of this web component as it appears in the DOM.";
     clickable = true;
-    const overview = "https://docs.webforj.com/docs/client-components/overview#:~:text=";
-    const nameInDOM = label.replace(/-/g, "%2D");
-    href = overview.concat(nameInDOM);
+    const path = "https://docs.webforj.com/docs/client-components/";
+    const clientPage = label.replace("dwc-", "");
+    href = path.concat(clientPage);
 
     iconName = 'code';
   } else if (chip == 'scoped') {

--- a/src/components/DocsTools/DocChip.js
+++ b/src/components/DocsTools/DocChip.js
@@ -38,7 +38,11 @@ export default function DocChip( { chip, label, href, clickable, iconName, toolt
   } else if (chip === 'name') {
     // A "DOM Name" chip
     tooltipText="The name of this web component as it appears in the DOM.";
-    clickable = false;
+    clickable = true;
+    const overview = "https://docs.webforj.com/docs/client-components/overview#:~:text=";
+    const nameInDOM = label.replace(/-/g, "%2D");
+    href = overview.concat(nameInDOM);
+
     iconName = 'code';
   } else if (chip == 'scoped') {
     tooltipText = "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.";

--- a/src/components/DocsTools/DocChip.js
+++ b/src/components/DocsTools/DocChip.js
@@ -9,7 +9,7 @@ import CodeIcon from '@mui/icons-material/Code';
 import DescriptionIcon from '@mui/icons-material/Description';
 import StyleIcon from '@mui/icons-material/Style';
 
-export default function DocChip( { chip, label, href, clickable, iconName, tooltipText, color  } ) {
+export default function DocChip( { chip, label, href, exclude, iconName, tooltipText, color  } ) {
 
   const mainStyles = css`
     margin-right: 0.5em;
@@ -31,22 +31,21 @@ export default function DocChip( { chip, label, href, clickable, iconName, toolt
   if(chip === 'shadow'){
     // A "Shadow DOM" Chip
     tooltipText = "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.";
-    clickable= true;
     href = "https://documentation.webforj.com/docs/glossary#shadow-dom";
     label='Shadow';
     iconName = 'shadow';
   } else if (chip === 'name') {
     // A "DOM Name" chip
     tooltipText="The name of this web component as it appears in the DOM.";
-    clickable = true;
-    const path = "https://docs.webforj.com/docs/client-components/";
-    const clientPage = label.replace("dwc-", "");
-    href = path.concat(clientPage);
-
+      if (!(exclude)){
+        const path = "https://docs.webforj.com/docs/client-components/";
+        const clientPage = label.replace("dwc-", "");
+        href = path.concat(clientPage);
+      }
     iconName = 'code';
   } else if (chip == 'scoped') {
     tooltipText = "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.";
-    clickable= false;
+    exclude= 'true';
     label='Scoped';
     iconName = 'scoped';  
   }
@@ -63,7 +62,7 @@ export default function DocChip( { chip, label, href, clickable, iconName, toolt
 
   return (
     <Tooltip title={tooltipText} arrow css={mainStyles} >
-      <Chip className={`doc-chip ${chip.className || ''}`} label={label} component="a" href={clickable ? href : null} icon={icon} clickable={clickable} color={color} target="_blank" />
+      <Chip className={`doc-chip ${chip.className || ''}`} label={label} component="a" href={ !exclude ? href : null} icon={icon} clickable={!exclude} color={color} target="_blank" />
     </Tooltip>
   )
 }


### PR DESCRIPTION
This PR closes Issue #414. In addition to going to the [Client Component Overview](https://docs.webforj.com/docs/client-components/overview), the chip will use its label to jump to the associated client component.